### PR TITLE
Use openssh upstream's SSH_AUTH_INFO_0 if present

### DIFF
--- a/pam_ssh_user_auth.c
+++ b/pam_ssh_user_auth.c
@@ -49,7 +49,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t * pamh, int flags,
 
     ssh_user_auth = get_ssh_user_auth(pamh, debug);
     if (ssh_user_auth == NULL) {
-        /* There was no SSH_USER_AUTH in the environment, which can be caused by:
+        /* There was no SSH_AUTH_INFO_0 or SSH_USER_AUTH in the environment, which can be caused by:
          *  - This feature not being supported by the installed version of OpenSSH
          *  - No previously successful authentications
          *  Here, we will assume that we are in the latter case
@@ -58,7 +58,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t * pamh, int flags,
     }
 
     /* We have no requirement on which authentication methods should be authorized
-     * As we have a non-empty SSH_USER_AUTH, accept the request
+     * As we have a non-empty SSH_AUTH_INFO_0 or SSH_USER_AUTH, accept the request
      * TODO: add a parameter containing the list of authorized auth methods.
      */
     return PAM_SUCCESS;

--- a/ssh_user_auth.c
+++ b/ssh_user_auth.c
@@ -10,15 +10,18 @@ const char * get_ssh_user_auth(pam_handle_t * pamh, int debug)
 {
 	const char * ssh_user_auth;
 
-	ssh_user_auth = pam_getenv(pamh, "SSH_USER_AUTH");
+	ssh_user_auth = pam_getenv(pamh, "SSH_AUTH_INFO_0");
 	if (ssh_user_auth == NULL) {
-		if (debug)
-			D("no SSH_USER_AUTH");
-		return NULL;
+		ssh_user_auth = pam_getenv(pamh, "SSH_USER_AUTH");
+		if (ssh_user_auth == NULL) {
+			if (debug)
+				D("no SSH_AUTH_INFO_0 or SSH_USER_AUTH");
+			return NULL;
+		}
 	}
 	if (strlen(ssh_user_auth) == 0) {
 		if (debug)
-			D("empty SSH_USER_AUTH");
+			D("empty SSH_AUTH_INFO_0 or SSH_USER_AUTH");
 		return NULL;
 	}
 	return ssh_user_auth;
@@ -50,7 +53,7 @@ char * extract_details(pam_handle_t * pamh, int debug, const char * method)
 	if (tok != NULL) {
 		tok += method_len;
 		if (*tok != ':' || *(tok + 1) != ' ') {
-			D("empty details in SSH_USER_AUTH");
+			D("empty details in SSH_AUTH_INFO_0 or SSH_USER_AUTH");
 		} else {
 			details = strdup(tok + 2);
 		}


### PR DESCRIPTION
This seems to make things work on Fedora.